### PR TITLE
Add animate page transitions for turbo drive

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -11,6 +11,11 @@ import Tooltip from "@ryangjchandler/alpine-tooltip";
 import { Turbo } from "@hotwired/turbo-rails"
 Turbo.setProgressBarDelay(100)
 
+// Animate page transitions for turbo
+import Turn from "@domchristie/turn";
+Turn.config.experimental.viewTransitions = true;
+Turn.start();
+
 window.dispatchMapsFormEvent = function (...args) {
   const event = new Event("google-maps-callback", { bubbles: true, cancelable: true });
   event.args = args;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "app",
   "private": "true",
   "dependencies": {
+    "@domchristie/turn": "^3.1.1",
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^7.3.0",
     "@rails/actiontext": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,6 +969,11 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
+"@domchristie/turn@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@domchristie/turn/-/turn-3.1.1.tgz#404536f25878eda1ac74e90285441a3fd7d428f3"
+  integrity sha512-hdS58VV28fhOCQbVu/tMKv5UIv8wDl12fiS2mmuD1sNhyMfeA99TqxsrM2IzvoXh3Izi/ry0QvfgQjwDiAOzow==
+
 "@esbuild/aix-ppc64@0.19.11":
   version "0.19.11"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz#2acd20be6d4f0458bc8c784103495ff24f13b1d3"


### PR DESCRIPTION
## Context
Add simple view transition for turbo drive event

https://domchristie.github.io/turn/examples/hybrid-basic/
https://github.com/domchristie/turn

Just use default animation for now, can be set[ custom animation](https://github.com/domchristie/turn?tab=readme-ov-file#customizing-animations) later 😄.


## Screencast

https://github.com/petakopi/petakopi.my/assets/7901659/fbb893a5-1b24-47c3-807c-3c280bf606a9


