### PR TITLE
fix(coffee-shop-new): adjust typo in shop name field

### DIFF
--- a/app/views/coffee_shops_v2/new.html.erb
+++ b/app/views/coffee_shops_v2/new.html.erb
@@ -49,7 +49,7 @@
             <div class="space-y-6 sm:space-y-5">
               <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
                 <%= f.label :name, class: "block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2" do %>
-                  Cofee Shop's Name*
+                  Coffee Shop's Name*
                   <div class="mt-1 text-sm text-gray-500">
                     Just the name and nothing else
                   </div>


### PR DESCRIPTION
## Changes
- Adjust typo in shop name field

| Preview  | Description |
| ------------- | ------------- |
| <img width="360" alt="Screenshot 2024-08-20 at 7 56 09 AM" src="https://github.com/user-attachments/assets/16fdff7d-29d7-4d00-95dc-1dcad0102b0d"> | Updated `Cofee` to `Coffee` |


